### PR TITLE
The invite code of events is visible to creators for sharing

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -26,6 +26,8 @@ const Login: React.FC = () => {
     // clear: clearToken, // is commented out because we do not need to clear the token when logging in
   } = useLocalStorage<string>("token", ""); // note that the key we are selecting is "token" and the default value we are setting is an empty string
   // if you want to pick a different token, i.e "usertoken", the line above would look as follows: } = useLocalStorage<string>("usertoken", "");
+  const { set: setUserId } = useLocalStorage<string>("userId", "");
+
 
   const handleLogin = async (values: FormFieldProps) => {
     try {
@@ -35,6 +37,10 @@ const Login: React.FC = () => {
       // Use the useLocalStorage hook that returned a setter function (setToken in line 41) to store the token if available
       if (response.token) {
         setToken(response.token);
+      }
+
+      if (response.id) {
+        setUserId(response.id);
       }
 
       // Navigate to the user overview

--- a/app/map/page.tsx
+++ b/app/map/page.tsx
@@ -39,6 +39,7 @@ export default function MapPage() {
   const { message: messageApi } = App.useApp();
 
   const { value: token, clear: clearToken } = useLocalStorage<string>("token", "");
+  const { value: userId, clear: clearUserId } = useLocalStorage<string>("userId", "");
   const [isMounted, setIsMounted] = useState(false);
 
   // Auth guard — delays check by one render to avoid SSR/localStorage issues
@@ -223,6 +224,7 @@ export default function MapPage() {
   const handleLogout = () => {
     setIsMounted(false);
     clearToken();
+    clearUserId();
     router.push("/login");
   };
 
@@ -469,6 +471,14 @@ export default function MapPage() {
                 <span style={{ color: "#6b7280", fontSize: "12px" }}>Participants</span>
                 <p style={{ margin: "2px 0 0 0", color: "#111827" }}>{selectedEvent.participantCount ?? 0}</p>
               </div>
+            </div>
+            <div>
+              {Number(userId) == selectedEvent.creatorId && (
+                <div>
+                  <span style={{ color: "#6b7280", fontSize: "12px" }}>Your Invite Code - visible to event creators only</span>
+                  <p style={{ margin: "2px 0 0 0", color: "#111827" }}>{selectedEvent.inviteCode ?? "—"}</p>
+                </div>
+              )}
             </div>
             <div>
               <span style={{ color: "#6b7280", fontSize: "12px" }}>Photos</span>

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -26,6 +26,7 @@ const Login: React.FC = () => {
     // clear: clearToken, // is commented out because we do not need to clear the token when logging in
   } = useLocalStorage<string>("token", ""); // note that the key we are selecting is "token" and the default value we are setting is an empty string
   // if you want to pick a different token, i.e "usertoken", the line above would look as follows: } = useLocalStorage<string>("usertoken", "");
+  const { set: setUserId } = useLocalStorage<string>("userId", "");
 
   const handleRegister = async (values: FormFieldProps) => {
     try {
@@ -35,6 +36,10 @@ const Login: React.FC = () => {
       // Use the useLocalStorage hook that returned a setter function (setToken in line 41) to store the token if available
       if (response.token) {
         setToken(response.token);
+      }
+
+      if (response.id) {
+        setUserId(response.id);
       }
 
       // Navigate to the user overview

--- a/app/types/event.ts
+++ b/app/types/event.ts
@@ -7,6 +7,7 @@ export interface EventDTO {
   latitude: number;
   longitude: number;
   isPrivate: boolean;
+  inviteCode: string | null;
   creatorId: number | null;
   creatorUsername: string | null;
   participantCount: number | null;


### PR DESCRIPTION
Creators of events can now see the invite code of their events when selecting the event marker on the map (non-creators cannot see the code). Additionally, userId is being now stored in the local storage which can be retrieved from there for also further checks in the code